### PR TITLE
Handle 429 (Too many requests) error response from Unifi Protect.

### DIFF
--- a/src/protect-api.ts
+++ b/src/protect-api.ts
@@ -940,6 +940,13 @@ export class ProtectApi {
         return null;
       }
 
+      // Too many requests.
+      if(response.status === 429) {
+        this.apiErrorCount = PROTECT_API_ERROR_LIMIT;
+        this.log.error("Too many requests. Will wait a while before next request. This can take a while to resolve, please make sure the Protect IP and credentials supplied are correct with suitable permissions.");
+        return null;
+      }
+
       // Some other unknown error occurred.
       if(!response.ok) {
         this.apiErrorCount++;


### PR DESCRIPTION
Currently, when a 429 is returned, it's handled just like any other unknown error, so continues to make requests without backing off. With this implementation, the first time we see 429 as the response code, it will force the plugin to enter the backoff delay period already set up.

This might not be enough of a delay and more work might be needed, as I was unable to find anything about how long the rate limiting is locked for. But waiting 5 mins between requests for now is better than nothing which is what currently happens.